### PR TITLE
Harden Log initialization and empty-state handling

### DIFF
--- a/src/main/java/es/enpici/logger/Log.java
+++ b/src/main/java/es/enpici/logger/Log.java
@@ -20,7 +20,7 @@ import java.util.Date;
 public class Log {
 
 
-    private static ArrayList<String> log;
+    private static ArrayList<String> log = new ArrayList<>(0);
     private static boolean traza = false;
     private static boolean continua = false;
 
@@ -58,9 +58,6 @@ public class Log {
      */
     public static void writeLog(String text, es.enpici.logger.Severity nivel, String clase) {
         if (traza) {
-            if (log == null) {
-                log = new ArrayList<>(0);
-            }
             DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
             Date date = new Date();
             String ntext = String.format("[ %s ][%s]:#%s# %s", dateFormat.format(date), nivel, clase, text);
@@ -109,6 +106,9 @@ public class Log {
      * @return String con el contenido del log
      */
     public static String toText() {
+        if (log == null || log.isEmpty()) {
+            return "";
+        }
         String salida = "";
         salida = log.stream().map((v) -> v + "\r\n").reduce(salida, String::concat);
         return salida;
@@ -118,6 +118,10 @@ public class Log {
      * Reinicia el log
      */
     public static void Restart() {
+        if (log == null) {
+            log = new ArrayList<>(0);
+            return;
+        }
         log.clear();
     }
 
@@ -125,7 +129,7 @@ public class Log {
      * Escribe el fichero Log.
      */
     public static void WriteFile() {
-        if (traza) {
+        if (traza && log != null && !log.isEmpty()) {
             WriteLog(toText());
         }
     }


### PR DESCRIPTION
### Motivation
- Evitar NullPointerException y flujos frágiles cuando las rutinas de logging se ejecutan sin entradas previas.
- Asegurar que `toText()` devuelva una cadena válida en estado vacío para que consumidores no tengan que comprobar `null`.
- Evitar intentos innecesarios de escritura cuando no hay entradas en `WriteFile()`.

### Description
- Inicializado `log` de forma temprana en la declaración como `private static ArrayList<String> log = new ArrayList<>(0);` para eliminar la inicialización perezosa dentro de `writeLog`.
- Eliminada la comprobación/creación redundante de `log` en `writeLog(String, Severity, String)` y mantenida la adición segura de entradas a `log`.
- Modificado `toText()` para devolver `""` cuando `log` es `null` o está vacío, evitando que las llamadas posteriores peten o reciban `null`.
- Hecho `Restart()` null-safe reponiendo `log` si es `null` y limpiándolo si ya existe.
- Cambiado `WriteFile()` para no llamar a `WriteLog(toText())` a menos que `traza` esté activa y `log` no sea `null` ni esté vacío.

### Testing
- Ejecutada una búsqueda estática por los identificadores objetivo con `rg` para validar que ya no hay caminos que asuman logs previos y la búsqueda devolvió las ubicaciones modificadas con éxito.
- Ejecutado `mvn -q test`, que falló por resolución de plugins en este entorno debido a un `403 Forbidden` al acceder a Maven Central, por lo que los tests unitarios no pudieron correrse aquí.
- Revisión manual del archivo `src/main/java/es/enpici/logger/Log.java` para verificar los cambios y flujos protegidos contra estados nulos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0405b9664832c8f0706b82900e3cb)